### PR TITLE
Update google-cloud-storage minium version higher than 1.30

### DIFF
--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'carrierwave', ['>= 1.3.2', '< 3']
-  spec.add_dependency 'google-cloud-storage', '~> 1.18.2'
+  spec.add_dependency 'google-cloud-storage', ['>= 1.30', '< 2']
 
   if RUBY_VERSION >= '2.2.2'
     spec.add_dependency 'activemodel', '>= 3.2.0'

--- a/lib/carrierwave-google-storage.rb
+++ b/lib/carrierwave-google-storage.rb
@@ -1,4 +1,4 @@
-require 'google-cloud-storage'
+require "google/cloud/storage"
 require 'carrierwave'
 require 'carrierwave/google/storage/version'
 require 'carrierwave/storage/gcloud'

--- a/lib/carrierwave-google-storage.rb
+++ b/lib/carrierwave-google-storage.rb
@@ -1,4 +1,4 @@
-require "google/cloud/storage"
+require 'google/cloud/storage'
 require 'carrierwave'
 require 'carrierwave/google/storage/version'
 require 'carrierwave/storage/gcloud'

--- a/lib/carrierwave/storage/gcloud.rb
+++ b/lib/carrierwave/storage/gcloud.rb
@@ -43,10 +43,10 @@ module CarrierWave
         @connection ||= begin
           conn_cache = self.class.connection_cache
           ENV['SSL_CERT_FILE'] = cert_path
-          conn_cache[credentials] ||= ::Google::Cloud.new(
-            credentials[:gcloud_project] || ENV['GCLOUD_PROJECT'],
-            credentials[:gcloud_keyfile] || ENV['GCLOUD_KEYFILE']
-          ).storage
+          conn_cache[credentials] ||= ::Google::Cloud::Storage.new(
+            project_id: credentials[:gcloud_project] || ENV['GCLOUD_PROJECT'],
+            credentials: credentials[:gcloud_keyfile] || ENV['GCLOUD_KEYFILE']
+          )
         end
       end
 

--- a/lib/carrierwave/storage/gcloud.rb
+++ b/lib/carrierwave/storage/gcloud.rb
@@ -42,7 +42,6 @@ module CarrierWave
       def connection
         @connection ||= begin
           conn_cache = self.class.connection_cache
-          ENV['SSL_CERT_FILE'] = cert_path
           conn_cache[credentials] ||= ::Google::Cloud::Storage.new(
             project_id: credentials[:gcloud_project] || ENV['GCLOUD_PROJECT'],
             credentials: credentials[:gcloud_keyfile] || ENV['GCLOUD_KEYFILE']
@@ -52,15 +51,6 @@ module CarrierWave
 
       def credentials
         uploader.gcloud_credentials || {}
-      end
-
-      private
-
-      def cert_path
-        @cert_path ||= begin
-          gem_path = Gem.loaded_specs['google-api-client'].full_gem_path
-          gem_path + '/lib/cacerts.pem'
-        end
       end
     end
   end


### PR DESCRIPTION
Hi! Thanks for creating this great library! I've been using it for years.

google-cloud-storage version 1.3 changed to use google-apis-iamcredentials_v1 and google-apis-storage_v1 instead of google-api-client. So google-cloud-storage has some minor changes. (google-api-client is deprecated now.) If you'd like to  know more detail, please read this [change log](https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-storage/CHANGELOG.md#1300--2021-01-13)