### PR TITLE
Relax google-cloud-storage requirement

### DIFF
--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'carrierwave', ['>= 1.3.2', '< 3']
-  spec.add_dependency 'google-cloud-storage', '~> 1.18.2'
+  spec.add_dependency 'google-cloud-storage', '~> 1.18'
 
   if RUBY_VERSION >= '2.2.2'
     spec.add_dependency 'activemodel', '>= 3.2.0'

--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'carrierwave', ['>= 1.3.2', '< 3']
   spec.add_dependency 'google-cloud-storage', '~> 1.18'
+  spec.add_dependency 'google-api-client', '~> 0.53'
 
   if RUBY_VERSION >= '2.2.2'
     spec.add_dependency 'activemodel', '>= 3.2.0'

--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -84,7 +84,7 @@ module CarrierWave
       end
 
       def authenticated_url(options = {})
-        bucket.signed_url(path, options)
+        bucket.signed_url(path, **options)
       end
 
       def public_url

--- a/lib/carrierwave/support/uri_filename.rb
+++ b/lib/carrierwave/support/uri_filename.rb
@@ -4,7 +4,7 @@ module CarrierWave
       def self.filename(url)
         path = url.split('?').first
 
-        URI.decode(path).gsub(/.*\/(.*?$)/, '\1')
+        URI.decode_www_form_component(path).gsub(/.*\/(.*?$)/, '\1')
       end
     end
   end


### PR DESCRIPTION
In 0.0.9 the requirement was more relaxed `~> 0.10` but in 1.0.0 it's more more
constrained at `~> 1.18.2`. This fix allows newer 1.x version of
google-cloud-storage to be installed

Additionaly this PR includes fix for ruby3 argument changes and adds google-api-client and a required dependancy